### PR TITLE
account for optional whitespace after currency symbol

### DIFF
--- a/ledger_to_beancount/__init__.py
+++ b/ledger_to_beancount/__init__.py
@@ -86,9 +86,9 @@ def translate_amount(amount):
     def replace_number(currency, match):
         amount = Decimal(match.group(1))
         return '{} {}'.format(str(amount), currency)
-    amount = re.sub(r'\$' + amount_re, partial(replace_number, 'USD'), amount)
-    amount = re.sub(r'€' + amount_re, partial(replace_number, 'EUR'), amount)
-    amount = re.sub(r'₤' + amount_re, partial(replace_number, 'GBP'), amount)
+    amount = re.sub(r'\$\s?' + amount_re, partial(replace_number, 'USD'), amount)
+    amount = re.sub(r'€\s?' + amount_re, partial(replace_number, 'EUR'), amount)
+    amount = re.sub(r'₤\s?' + amount_re, partial(replace_number, 'GBP'), amount)
     return amount
 
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -158,6 +158,23 @@ def test_currency_is_translated():
       Assets:Cash
     """)
 
+def test_currency_with_spaces_is_translated():
+    """$ 40 -> 40 USD"""
+    input = from_triple_quoted_string("""
+    2017-01-02 An ordinary transaction
+        Expenses:Restaurants    $ 40
+        Assets:Cash
+    """)
+    output = translate_file(input)
+    assert output == from_triple_quoted_string("""
+    * Accounts
+    2010-01-01 open Assets:Cash
+    2010-01-01 open Expenses:Restaurants
+    * Transactions
+    2017-01-02 * "An ordinary transaction"
+      Expenses:Restaurants        40 USD
+      Assets:Cash
+    """)
 
 def test_negative_currency_is_translated():
     """$-40 -> -40 USD, as is -$40"""


### PR DESCRIPTION
For issue https://github.com/glasserc/ledger-to-beancount/issues/2

Squashed commits:
[1f53921] account for optional whitespace after currency symbol