### PR TITLE
Use pound sign, not lira, when converting GBP

### DIFF
--- a/ledger_to_beancount/__init__.py
+++ b/ledger_to_beancount/__init__.py
@@ -121,7 +121,7 @@ def translate_amount(amount):
         return '{} {}'.format(str(amount), currency)
     amount = re.sub(r'\$\s?' + amount_re, partial(replace_number, 'USD'), amount)
     amount = re.sub(r'€\s?' + amount_re, partial(replace_number, 'EUR'), amount)
-    amount = re.sub(r'₤\s?' + amount_re, partial(replace_number, 'GBP'), amount)
+    amount = re.sub(r'£\s?' + amount_re, partial(replace_number, 'GBP'), amount)
 
     (amount, units) = parse_amount_and_units(amount)
     # Ledger supports "quoted" commodities, which can support numbers.

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -162,6 +162,25 @@ def test_currency_is_translated():
     """)
 
 
+def test_currency_with_pound_sign_is_translated():
+    """£40 -> 40 GBP"""
+    input = from_triple_quoted_string("""
+    2017-01-02 An ordinary transaction
+        Expenses:Restaurants    £40
+        Assets:Cash
+    """)
+    output = translate_file(input)
+    assert output == from_triple_quoted_string("""
+    * Accounts
+    2010-01-01 open Assets:Cash
+    2010-01-01 open Expenses:Restaurants
+    * Transactions
+    2017-01-02 * "An ordinary transaction"
+      Expenses:Restaurants        40 GBP
+      Assets:Cash
+    """)
+
+
 def test_currency_with_spaces_is_translated():
     """$ 40 -> 40 USD"""
     input = from_triple_quoted_string("""


### PR DESCRIPTION
The character previously used to convert values written with a
pound sign (e.g. £3.14) was actually the lira sign (₤). This changes
it to a pound sign (£). This is the character than shift+3 produces
on a UK keyboard.